### PR TITLE
Enable tests on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.4"
+
+env:
+  - DJANGO_VERSION=1.6.10
+  - DJANGO_VERSION=1.7.4
+  - DJANGO_VERSION=1.8a1
+
+matrix:
+  exclude:
+    - python: "3.4"
+      env: DJANGO_VERSION=1.6.10
+
+install:
+  - "npm install -g npm"
+  - "pip install Django==$DJANGO_VERSION"
+  - "pip install -r requirements.txt"
+
+  # This needs to install with -e in order for test settings file to be visible.
+  - "pip install -e ."
+
+script: python django_webpack/tests/run_tests.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Django Webpack
 ==============
 
+[![Build Status](https://travis-ci.org/markfinger/django-webpack.svg?branch=master)](https://travis-ci.org/markfinger/django-webpack)
+
 Generate Webpack bundles from a Django application.
 ```python
 from django_webpack import WebpackBundle

--- a/django_webpack/bundle.py
+++ b/django_webpack/bundle.py
@@ -1,6 +1,5 @@
 import os
 import json
-from django.contrib.staticfiles import finders
 from django.utils.safestring import mark_safe
 from django_node import npm, node
 from .exceptions import NoEntryFileDefined, EntryFileNotFound, BundlingError
@@ -157,6 +156,9 @@ class WebpackBundle(object):
         return self.entry
 
     def get_path_to_entry(self):
+        # Imported here to prevent early settings access in Django 1.6
+        from django.contrib.staticfiles import finders
+
         entry = self.get_entry()
         if not entry:
             raise NoEntryFileDefined(self)

--- a/django_webpack/tests/run_tests.py
+++ b/django_webpack/tests/run_tests.py
@@ -2,13 +2,18 @@ import os
 import sys
 
 import django
-from django.conf import settings
-from django.test.utils import get_runner
+
 
 if __name__ == '__main__':
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
     os.environ['DJANGO_SETTINGS_MODULE'] = 'django_webpack.tests.test_settings'
-    django.setup()
+    if hasattr(django, 'setup'):  # Only compatible with Django >= 1.7
+        django.setup()
+
+    # For Django 1.6, need to import after setting DJANGO_SETTINGS_MODULE.
+    from django.conf import settings
+    from django.test.utils import get_runner
+
     TestRunner = get_runner(settings)
     test_runner = TestRunner()
     failures = test_runner.run_tests(['django_webpack'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django
-django-node==2.3.3
+django-node>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     },
     install_requires=[
         'django',
-        'django-node==2.3.3',
+        'django-node>=3.0.0',
     ],
     description='Generate Webpack bundles from a Django application.',
     long_description='Documentation at https://github.com/markfinger/django-webpack',


### PR DESCRIPTION
Note: to fully work this will require you to sign up at travis-ci.org if you haven't already, and then to enable builds for the markfinger/django-webpack repo.

Rollup of the following changes:
- Adds a .travis.yml config file
- Depend on latest django-node release
- Don't run tests on Python 3.4 + Django 1.6
- Django 1.6.4 compatibility for test runner
- Prevent early settings access in Django 1.6
- Add build status badge to README
